### PR TITLE
Fix for error message "Index out of bounds in pdf1D_t"

### DIFF
--- a/include/utilities/sample_utils.h
+++ b/include/utilities/sample_utils.h
@@ -125,12 +125,11 @@ public:
 		// Find surrounding cdf segments
 		float *ptr = std::lower_bound(cdf, cdf+count+1, u);
 		int index = (int) (ptr-cdf-1);
-		if(index<0)
+		if(index<0)	//Hopefully this should no longer be necessary from now on, as a minimum value slightly over 0.f has been set to the scrHalton function to avoid ptr and cdf to coincide (which caused index = -1)
 		{
 		    Y_ERROR << "Index out of bounds in pdf1D_t::Sample: index, u, ptr, cdf = " << index << ", " << u << ", " << ptr << ", " << cdf << yendl;
 		    index=0;
 		}
-             //FIXME: this is one of the fixes for the white dots. Sometimes for some reason this index was -1, causing an access outside the array and an invalid value->NaN, inf, etc. Now, we ensure the index does not move <0, but we should look for a better solution to prevent the index to go <0 in the first place.
 		// Return offset along current cdf segment
 		float delta = (u - cdf[index]) / (cdf[index+1] - cdf[index]);
 		if(pdf) *pdf = func[index] * invIntegral;
@@ -147,7 +146,7 @@ public:
 		}
 		float *ptr = std::lower_bound(cdf, cdf+count+1, u);
 		int index = (int) (ptr-cdf-1);
-		if(index<0)
+		if(index<0)	//Hopefully this should no longer be necessary from now on, as a minimum value slightly over 0.f has been set to the scrHalton function to avoid ptr and cdf to coincide (which caused index = -1)
 		{
 		    Y_ERROR << "Index out of bounds in pdf1D_t::Sample: index, u, ptr, cdf = " << index << ", " << u << ", " << ptr << ", " << cdf << yendl;
 		    index=0;

--- a/include/yafraycore/scr_halton.h
+++ b/include/yafraycore/scr_halton.h
@@ -65,7 +65,7 @@ inline double scrHalton(int dim, unsigned int n)
 	{
 		value = (double)ourRandom();
 	}
-	return std::max(0.0, std::min(1.0, value));
+	return std::max(1.0e-36, std::min(1.0, value));	//A minimum value very small 1.0e-36 is set to avoid issues with pdf1D sampling in the Sample function with s2=0.f Hopefully in practice the numerical difference between 0.f and 1.0e-36 will not be significant enough to cause other issues.
 }
 
 __END_YAFRAY


### PR DESCRIPTION
Ocasionally we get the message "Index out of bounds in pdf1D_t::Sample: index, u, ptr, cdf = ". This is an old problem that used to cause black dots and was "patched" with this message and forcing the index to be within bounds, but the actual cause for the index going out of bounds was never found.

povmaniaco has reported the problem in the bug tracker and provided a way to replicate it with spotlights with falloff > 0.70 and caustic photons enabled. More information:
http://yafaray.org/node/681

I could replicate it with a single spotlight and this problem also affects background lights with, for example, EXR textures + IBL + use caustics

Now, I believe the problem is caused by scrHalton function, as it sometimes gives a result exactly=0.f. When in mcintegrator we get s2=0.f exactly, if the light uses Sample(s2, ...) for photon emission, the Sample function has ptr=cdf and therefore the index becomes -1, out of bounds.

So, I've added a minimum value to the scrHalton function. I tried to use a very very small minimum value (it was 0.f before, and I changed it to 1.0e-36, which is really close to 0.f). It seems to fix the problem and I think such a small minimum value should not cause other problems in the render process (I hope!)