### PR TITLE
Fix issue when pointer to string was printed.

### DIFF
--- a/src/textures/basicnodes.cc
+++ b/src/textures/basicnodes.cc
@@ -260,7 +260,7 @@ shaderNode_t* textureMapper_t::factory(const paraMap_t &params,renderEnvironment
 	tex = render.getTexture(*texname);
 	if(!tex)
 	{
-		Y_ERROR << "TextureMapper: texture '" << texname << "' does not exist!" << yendl;
+		Y_ERROR << "TextureMapper: texture '" << *texname << "' does not exist!" << yendl;
 		return 0;
 	}
 	textureMapper_t *tm = new textureMapper_t(tex);


### PR DESCRIPTION
Fix an issue when the pointer to the texture name was printed
instead of the string (the name of the texture) itself.